### PR TITLE
Gérer les clés de l'API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,24 @@
 
-# Created by https://www.toptal.com/developers/gitignore/api/python,jupyternotebooks,vscode
-# Edit at https://www.toptal.com/developers/gitignore?templates=python,jupyternotebooks,vscode
+### Config file with the API key ###
+scripts/twitter_credentials.py
+
+### Template with Data, JupyterNotebboks, Python, vscode ###
+# Created by https://www.toptal.com/developers/gitignore/api/python,jupyternotebooks,vscode,Data
+# Edit at https://www.toptal.com/developers/gitignore?templates=python,jupyternotebooks,vscode,Data
+
+### Data ###
+*.csv
+*.dat
+*.efx
+*.gbr
+*.key
+*.pps
+*.ppt
+*.pptx
+*.sdf
+*.tax2010
+*.vcf
+*.xml
 
 ### JupyterNotebooks ###
 # gitignore template for Jupyter Notebooks
@@ -153,20 +171,6 @@ dmypy.json
 # profiling data
 .prof
 
-### Data ###
-*.csv
-*.dat
-*.efx
-*.gbr
-*.key
-*.pps
-*.ppt
-*.pptx
-*.sdf
-*.tax2010
-*.vcf
-*.xml
-
 ### vscode ###
 .vscode/*
 !.vscode/settings.json
@@ -175,4 +179,4 @@ dmypy.json
 !.vscode/extensions.json
 *.code-workspace
 
-# End of https://www.toptal.com/developers/gitignore/api/python,jupyternotebooks,vscode
+# End of https://www.toptal.com/developers/gitignore/api/python,jupyternotebooks,vscode,Data


### PR DESCRIPTION
Pour gérer le problème lié au clés de l'API dans un repo public.

Il faut créer twitter_credentials.py localement.
Sous le format :
```python
consumer_key = api_key = "" # À compléter
consumer_secret = api_secret_key = ""
access_token = ""
access_token_secret = ""
bearer_token = ""
```


Close #2 